### PR TITLE
fix: reset transcript when starting a new recording

### DIFF
--- a/web/src/components/RecordingToggle/RecordingToggle.tsx
+++ b/web/src/components/RecordingToggle/RecordingToggle.tsx
@@ -27,7 +27,8 @@ export const RecordingToggle: FC<RecordProps> = ({
   onRecordingToggle,
   onTranscriptionChange
 }) => {
-  const [finalTranscript, setFinalTranscript] = useState<TranscriptionData>()
+  const [finalTranscript, setFinalTranscript] =
+    useState<TranscriptionData | null>(null)
   const [isRecording, setIsRecording] = useState<boolean>(false)
   const [isIgnoreRecognitionOnEnd, setIsIgnoreRecognitionOnEnd] =
     useState<boolean>(false)
@@ -59,6 +60,7 @@ export const RecordingToggle: FC<RecordProps> = ({
   }
 
   const recognitionOnStartHandler = () => {
+    setFinalTranscript(null)
     setIsRecording(true)
   }
 


### PR DESCRIPTION
Resolves #38 

Reset the transcript when a new recording starts. This prevents the previous transcript from being reused if the recording is stopped before any event occurs.