### PR TITLE
chore: bump husky to version 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev": "npm run dev --workspace=server & npm run dev --workspace=web",
     "lint": "npm run lint --ws",
     "test": "npm run test --ws",
-    "prepare": "npx husky install",
+    "prepare": "npx husky",
     "build": "npm run build -w web"
   },
   "repository": {


### PR DESCRIPTION
Updated Husky to latest version. Migration guide found [here](https://github.com/typicode/husky/releases/tag/v9.0.1)